### PR TITLE
Correct URL without http://

### DIFF
--- a/Classes/Controller/FetchController.php
+++ b/Classes/Controller/FetchController.php
@@ -55,6 +55,12 @@ class FetchController extends ActionController
      */
     public function iframeAction()
     {
+		// Checking if the requested url starts with http:// or https://
+		$url = $this->settings['main']['url'];
+		if (!preg_match("@^https?://@", $url)) {
+			$this->settings['main']['url']= "//" . $url;
+			$this->view->assign('settings', $this->settings);
+		}
         $this->assignForAllActions();
     }
     


### PR DESCRIPTION
This will add a "//" in front of the URL for iframes without http:// or
https://. I prefer using // in case the Typo3 website uses https, in
that case the remote content has to be https.

There might be a better way of doing it though.