### PR TITLE
[TASK] Change composer dependency for TYPO3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "type": "typo3-cms-extension",
   "license": "GPL-3.0",
   "require": {
-    "typo3/cms": ">=6.2.0 <9.9.99"
+    "typo3/cms-core": ">=6.2.0 <9.9.99"
   },
   "replace": {
     "fetchurl": "self.version"


### PR DESCRIPTION
The composer dependency for TYPO3 must be `typo3/cms-core`. The old one
breaks the subtree split and loads all system extensions.