### PR TITLE
Added feature to optionally forward the typo3 url on static fetch

### DIFF
--- a/Classes/Controller/FetchController.php
+++ b/Classes/Controller/FetchController.php
@@ -46,6 +46,7 @@ class FetchController extends ActionController
      */
     public function fetchAction()
     {
+        $this->settings["originalUrl"] = $this->uriBuilder->getRequest()->getRequestUri();
         $this->view->assign('html', $this->objectManager->get(FetchService::class, $this->settings));
         $this->assignForAllActions();
     }
@@ -74,4 +75,5 @@ class FetchController extends ActionController
     {
         $this->contentObject = $this->configurationManager->getContentObject();
     }
+
 }

--- a/Classes/Domain/Service/FetchService.php
+++ b/Classes/Domain/Service/FetchService.php
@@ -70,6 +70,9 @@ class FetchService
      */
     protected function getContentFromUrl()
     {
+        if ($this->settings["main"]["forwardUrl"]) {
+            return GeneralUtility::getUrl($this->getUrl(), 0, ["Referer" => $this->settings["originalUrl"]]);
+        }
         return GeneralUtility::getUrl($this->getUrl());
     }
 

--- a/Configuration/FlexForm/FlexFormPi1.xml
+++ b/Configuration/FlexForm/FlexFormPi1.xml
@@ -17,6 +17,7 @@
 							<config>
 								<type>select</type>
 								<renderType>selectSingle</renderType>
+								<default>Fetch->fetch;</default>
 								<items type="array">
 									<numIndex index="1" type="array">
 										<numIndex index="0">LLL:EXT:fetchurl/Resources/Private/Language/locallang_db.xlf:flexform.main.view.0</numIndex>
@@ -42,6 +43,21 @@
 							</config>
 						</TCEforms>
 					</settings.main.url>
+					<settings.main.forwardUrl>
+						<TCEforms>
+							<displayCond><![CDATA[FIELD:switchableControllerActions:=:Fetch->fetch;]]></displayCond>
+							<exclude>1</exclude>
+							<label>LLL:EXT:fetchurl/Resources/Private/Language/locallang_db.xlf:flexform.main.forwardUrl</label>
+							<config>
+								<type>check</type>
+								<items type="array">
+									<numIndex index="1" type="array">
+										<numIndex index="0">LLL:EXT:fetchurl/Resources/Private/Language/locallang_db.xlf:flexform.main.forwardUrl</numIndex>
+									</numIndex>
+								</items>
+							</config>
+						</TCEforms>
+					</settings.main.forwardUrl>
 					<settings.main.width>
 						<TCEforms>
 							<displayCond><![CDATA[FIELD:switchableControllerActions:=:Fetch->iframe;]]></displayCond>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -18,6 +18,9 @@
 			<trans-unit id="flexform.main.url">
 				<source>Url to fetch</source>
 			</trans-unit>
+			<trans-unit id="flexform.main.forwardUrl">
+				<source>Forward URL</source>
+			</trans-unit>
 			<trans-unit id="flexform.main.width">
 				<source>iFrame width</source>
 			</trans-unit>


### PR DESCRIPTION
This pull request adds an additional checkbox to the fetch-url plugin which forwards the current url to the server where the the resource fetches from. This is intended to be used in cases were a single instance of the fetch-url plugin should be used to fetch different contents depending on the query-parameter of the url. This can for example be used for filtering the content of the fetched resource on the (external) server.