### PR TITLE
preserve port information when adding parameters to url

### DIFF
--- a/Classes/Domain/Service/UrlAppendService.php
+++ b/Classes/Domain/Service/UrlAppendService.php
@@ -41,7 +41,13 @@ class UrlAppendService
 
             $urlParts['query'] = http_build_query($params);
 
-            $url = $urlParts['scheme'] . '://' . $urlParts['host'] . $urlParts['path'];
+            $url = $urlParts['scheme'] . '://' . $urlParts['host'];
+
+            if (isset($urlParts['port'])) {
+                $url .= ':' . $urlParts['port'];
+            }
+            
+            $url .= $urlParts['path'];
 
             if (!empty($urlParts['query'])) {
                 $url .= '?' . $urlParts['query'];


### PR DESCRIPTION
currently port information is lost when adding parameters to a url.

so `https://example.com:9443` becomes `https://example.com/?parameter=123`.

this pr should fix the issue (am no php expert).